### PR TITLE
Enable Team Message Stats in default HUD

### DIFF
--- a/inc/default/team_message.hud
+++ b/inc/default/team_message.hud
@@ -2,25 +2,23 @@
 // MESSAGE
 //
 
-// what does this do
-/*if %MESSAGE_SELF
+if %MESSAGE_SELF
 	setColor 1 1 1 1
 	setCursor #WIDTH / 2, 380
 	setAlign 2 1
 	setFontFamily con_fontSystem
 	setFontSize con_fontSystemSmall
 	drawStatString %MESSAGE_SELF
-endif*/
+endif
 
-// what does this do
-/*if %MESSAGE_OTHER
+if %MESSAGE_OTHER
 	setColor 1 1 1 1
 	setCursor #WIDTH / 2, #HEIGHT / 2
 	setAlign 2 1
 	setFontFamily con_fontSystem
 	setFontSize con_fontSystemSmall
 	drawStatString %MESSAGE_OTHER
-endif*/
+endif
 
 //
 // Draw CA players remaining icons


### PR DESCRIPTION
https://github.com/TeamForbiddenLLC/huds/blob/bf9cfa88c772a2930cde2219382333d7ab1780f4/inc/team_info.hud#L196

This allows you to see the state of an item/state when placing your crosshair on a related object. For example, this allows you to see the name and defrost % of a frozen teammate when your crosshair is on their indicator.